### PR TITLE
Add missing 'async' dependency

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var _ = require('underscore');
+var async = require('async');
 
 var ProxyLists = module.exports = {
 


### PR DESCRIPTION
Fixes `async is not defined` error