### PR TITLE
Source Update: freeproxylist

### DIFF
--- a/sources/freeproxylist.js
+++ b/sources/freeproxylist.js
@@ -13,6 +13,62 @@ var convert = {
 	},
 };
 
+var startUrls = [
+	'https://free-proxy-list.net/',
+	'https://www.us-proxy.org/',
+	'https://free-proxy-list.net/uk-proxy.html',
+	'https://www.sslproxies.org/',
+	'https://free-proxy-list.net/anonymous-proxy.html',
+];
+
+var listDefinition = {
+	link: {
+		url: null,
+	},
+	items: [{
+		selector: '#proxylisttable tbody tr',
+		attributes: [
+			{
+				name: 'ipAddress',
+				selector: 'td:nth-child(1)',
+			},
+			{
+				name: 'port',
+				selector: 'td:nth-child(2)',
+				parse: function(text) {
+					var port = parseInt(text);
+					if (_.isNaN(port)) return null;
+					return port;
+				},
+			},
+			{
+				name: 'anonymityLevel',
+				selector: 'td:nth-child(5)',
+				parse: function(text) {
+					if (!text) return null;
+					text = text.trim().toLowerCase();
+					return convert.anonymityLevels[text] || null;
+				},
+			},
+			{
+				name: 'protocols',
+				selector: 'td:nth-child(7)',
+				parse: function(text) {
+					if (!text) return null;
+					text = text.trim().toLowerCase();
+					var protocol = convert.protocols[text] || 'http';
+					return [protocol];
+				},
+			},
+		],
+	}],
+	pagination: {
+		next: {
+			selector: '#proxylisttable_next > a',
+		},
+	},
+}
+
 module.exports = {
 	homeUrl: 'https://free-proxy-list.net/',
 	abstract: 'list-crawler',
@@ -20,52 +76,10 @@ module.exports = {
 		defaultTimeout: 5000,
 	},
 	config: {
-		lists: [{
-			link: {
-				url: 'https://free-proxy-list.net/',
-			},
-			items: [{
-				selector: '#proxylisttable tbody tr',
-				attributes: [
-					{
-						name: 'ipAddress',
-						selector: 'td:nth-child(1)',
-					},
-					{
-						name: 'port',
-						selector: 'td:nth-child(2)',
-						parse: function(text) {
-							var port = parseInt(text);
-							if (_.isNaN(port)) return null;
-							return port;
-						},
-					},
-					{
-						name: 'anonymityLevel',
-						selector: 'td:nth-child(5)',
-						parse: function(text) {
-							if (!text) return null;
-							text = text.trim().toLowerCase();
-							return convert.anonymityLevels[text] || null;
-						},
-					},
-					{
-						name: 'protocols',
-						selector: 'td:nth-child(7)',
-						parse: function(text) {
-							if (!text) return null;
-							text = text.trim().toLowerCase();
-							var protocol = convert.protocols[text] || 'http';
-							return [protocol];
-						},
-					},
-				],
-			}],
-			pagination: {
-				next: {
-					selector: '#proxylisttable_next > a',
-				},
-			},
-		}],
+		lists: _.map(startUrls, function(startUrl) {
+			return _.extend({}, listDefinition, {
+				link: { url: startUrl },
+			});
+		}),
 	},
 };


### PR DESCRIPTION
The source https://free-proxy-list.net/ has some adjacent top level urls with the same page structure such as https://www.us-proxy.org/ and https://www.sslproxies.org/ so I added them as alternative start URLs to pull more proxies.